### PR TITLE
soem_beckhoff_drivers: Consistently use 2^n-1 for the range value

### DIFF
--- a/soem_beckhoff_drivers/src/soem_el3062.cpp
+++ b/soem_beckhoff_drivers/src/soem_el3062.cpp
@@ -36,7 +36,7 @@ namespace soem_beckhoff_drivers
 {
 
 SoemEL30xx::SoemEL30xx(ec_slavet* mem_loc) :
-    soem_master::SoemDriver(mem_loc), m_size(2), m_raw_range(32768), m_lowest(
+    soem_master::SoemDriver(mem_loc), m_size(2), m_raw_range(32767), m_lowest(
             0.0), m_highest(10.0), m_values(m_size), m_raw_values(m_size),
             m_values_port("values"), m_raw_values_port("raw_values")
 

--- a/soem_beckhoff_drivers/src/soem_el30xx.cpp
+++ b/soem_beckhoff_drivers/src/soem_el30xx.cpp
@@ -39,11 +39,11 @@ namespace
 {
 soem_master::SoemDriver* createSoemEL3052(ec_slavet* mem_loc)
 {
-    return new SoemEL30xx<2>(mem_loc,32768,4,20);
+    return new SoemEL30xx<2>(mem_loc,32767,4,20);
 }
 soem_master::SoemDriver* createSoemEL3062(ec_slavet* mem_loc)
 {
-    return new SoemEL30xx<2>(mem_loc,32768,0,10);
+    return new SoemEL30xx<2>(mem_loc,32767,0,10);
 }
 soem_master::SoemDriver* createSoemEL3004(ec_slavet* mem_loc)
 {

--- a/soem_beckhoff_drivers/src/soem_el3104.cpp
+++ b/soem_beckhoff_drivers/src/soem_el3104.cpp
@@ -36,7 +36,7 @@ namespace soem_beckhoff_drivers
 {
 
 SoemEL3104::SoemEL3104(ec_slavet* mem_loc) :
-    soem_master::SoemDriver(mem_loc), m_size(4), m_raw_range(65536), m_lowest(
+    soem_master::SoemDriver(mem_loc), m_size(4), m_raw_range(65535), m_lowest(
             -10.0), m_highest(10.0), m_values(m_size), m_raw_values(m_size),m_params(m_size),
             m_values_port("values"), m_raw_values_port("raw_values")
 

--- a/soem_beckhoff_drivers/src/soem_el4xxx.cpp
+++ b/soem_beckhoff_drivers/src/soem_el4xxx.cpp
@@ -35,35 +35,35 @@ namespace
 {
 soem_master::SoemDriver* createSoemEL4002(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<2> (mem_loc, 32768, 0.0, 10.0);
+    return new SoemEL4xxx<2> (mem_loc, 32767, 0.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4004(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<4> (mem_loc, 32768, 0.0, 10.0);
+    return new SoemEL4xxx<4> (mem_loc, 32767, 0.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4008(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<8> (mem_loc, 32768, 0.0, 10.0);
+    return new SoemEL4xxx<8> (mem_loc, 32767, 0.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4022(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<2> (mem_loc, 32768, 4., 20.);
+    return new SoemEL4xxx<2> (mem_loc, 32767, 4., 20.);
 }
 soem_master::SoemDriver* createSoemEL4032(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<2> (mem_loc, 65536, -10.0, 10.0);
+    return new SoemEL4xxx<2> (mem_loc, 65535, -10.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4034(ec_slavet* mem_loc) //Resolution wrong????
 {
-    return new SoemEL4xxx<4> (mem_loc, 65536, -10.0, 10.0);
+    return new SoemEL4xxx<4> (mem_loc, 65535, -10.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4038(ec_slavet* mem_loc)
 {
-    return new SoemEL4xxx<8> (mem_loc, 65536, -10.0, 10.0);
+    return new SoemEL4xxx<8> (mem_loc, 65535, -10.0, 10.0);
 }
 soem_master::SoemDriver* createSoemEL4134(ec_slavet* mem_loc) // Added by Bert
 {
-    return new SoemEL4xxx<4> (mem_loc, 65536, -10.0, 10.0);
+    return new SoemEL4xxx<4> (mem_loc, 65535, -10.0, 10.0);
 }
 
 


### PR DESCRIPTION
Previously, 2^n was used (where n is resolution of the module).
The EL4002 will be used as an example.
The EL4002 is an analog output module which supports 0 to 10V output.
When 2^n is used as the range of this module, 0V will be the output
as a result of module.write(10) due to integer overflow.
The module does support 10V output. When 2^n-1 is used, the module
does indeed output 10V as a result of module.write(10).

Signed-off-by: Johan Robben <jrobben@octinion.com>