### PR TITLE
EL5101 multiple mappings

### DIFF
--- a/soem_beckhoff_drivers/src/soem_el5101.cpp
+++ b/soem_beckhoff_drivers/src/soem_el5101.cpp
@@ -28,6 +28,8 @@
 #include "soem_el5101.h"
 #include <soem_master/soem_driver_factory.h>
 
+using namespace RTT;
+
 namespace soem_beckhoff_drivers
 {
 
@@ -85,6 +87,22 @@ SoemEL5101::SoemEL5101(ec_slavet* mem_loc) :
 
 }
 
+
+bool SoemEL5101::start()
+{
+    input_length=m_datap->Ibytes;
+    if (input_length==5 || input_length==6 || input_length==10)
+    {
+        log(Warning) << "[EL5101] Found a correct mapping with size: " << input_length << " Bytes" << endlog();
+        return true;
+    }
+    else
+    {
+        log(Warning) << "[EL5101] Not found a correct mapping. Size of receiving mapping: " << input_length << " Bytes" << endlog();
+        return false;
+    }
+}
+
 void SoemEL5101::update()
 {
     //publish encoder values
@@ -94,7 +112,22 @@ void SoemEL5101::update()
 
 uint32_t SoemEL5101::read(void)
 {
-    return ((in_el5101t*) (m_datap->inputs))->invalue;
+    if (input_length==5)
+    {
+        return ((in_el5101t_5*) (m_datap->inputs))->invalue;
+    }
+    else if (input_length==6)
+    {
+        return ((in_el5101t_6*) (m_datap->inputs))->invalue;
+    }
+    else if (input_length==10)
+    {
+        return ((in_el5101t_10*) (m_datap->inputs))->invalue;
+    }
+    else
+    {
+        return ((in_el5101t_old*) (m_datap->inputs))->invalue;
+    }
 }
 
 /*double SoemEL5101::read_out( void){
@@ -127,5 +160,4 @@ REGISTER_SOEM_DRIVER(EL5101, createSoemEL5101)
 }
 
 }//namespace
-
 

--- a/soem_beckhoff_drivers/src/soem_el5101.h
+++ b/soem_beckhoff_drivers/src/soem_el5101.h
@@ -35,6 +35,7 @@
 #include <bitset>
 #include <vector>
 
+using namespace RTT;
 namespace soem_beckhoff_drivers
 {
 
@@ -55,7 +56,28 @@ class SoemEL5101: public soem_master::SoemDriver
       uint32 frequency;
       uint16 period;
       uint16 window;
-    } in_el5101t;
+    } in_el5101t_old;
+    
+    typedef struct PACKED
+    {
+      uint16 status;
+      uint32 invalue;
+      uint32 latch;
+    } in_el5101t_10;
+    
+    typedef struct PACKED
+    {
+      uint16 status;
+      uint16 invalue;
+      uint16 latch;
+    } in_el5101t_6;
+    
+    typedef struct PACKED
+    {
+      uint8 status;
+      uint16 invalue;
+      uint16 latch;
+    } in_el5101t_5;
 
  public:
     SoemEL5101(ec_slavet* mem_loc);
@@ -72,6 +94,7 @@ class SoemEL5101: public soem_master::SoemDriver
       unsigned int status(void);*/
 
     virtual void update();
+    bool start();
 
 private:
 
@@ -89,6 +112,8 @@ private:
   RTT::OutputPort<EncoderMsg> values_port_;
   RTT::Property<std::string> propriete;
   std::vector<parameter> params;
+  
+  uint input_length;
 };
   
 }


### PR DESCRIPTION
Changed the EL5101 driver to detect length of the input mapping and use different mappings based on the length of the receiving mapping. For each length, there is only one unique mapping predefined by Beckhoff.